### PR TITLE
Add env.sh which sources both Python .venv and zephyr-env.sh

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,0 +1,5 @@
+# Oneliner from: https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
+here=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+source $here/.venv/bin/activate
+source $here/deps/zephyr/zephyr-env.sh


### PR DESCRIPTION
If the user has multiple installations of Zephyr, the wrong zephyr version might potentially be selected. For me, this caused a crash on one of the basic timer programs, because I had an installation of version 3.6.0-rc3 instead of version 3.5.0. The solution is the source the zephyr-env.sh in the deps/zephyr folder to ensure that zephyr is used.

I think the best approach is to gather sourcing .venv/bin/activate and deps/zephyr/zephyr-env.sh in a single file, so the user does not need to remember to do both. Docs must be updated to reflect this as well, though.